### PR TITLE
Første siden av Utvikler-manualen

### DIFF
--- a/dapla-manual/_quarto.yml
+++ b/dapla-manual/_quarto.yml
@@ -31,6 +31,8 @@ website:
     left:
       - text: Manual
         href: statistikkere/index.qmd
+      - text: Utviklere
+        href: utviklere/lenker.qmd
       - text: Eksempler
         href: notebooks/index.qmd
       - text: "Blogg"
@@ -148,6 +150,10 @@ website:
             - statistikkere/spark.qmd
             - statistikkere/altinn3.qmd
             - statistikkere/kartdata.qmd
+    - id: utviklere
+      collapse-level: 1
+      contents:
+        - utviklere/lenker.qmd
     - id: eksempler
       collapse-level: 1
       contents:

--- a/dapla-manual/utviklere/lenker.qmd
+++ b/dapla-manual/utviklere/lenker.qmd
@@ -2,6 +2,13 @@
 
 Dokumentasjon for utviklere i SSB er spredt over mange ulike sider. Denne siden er en oversikt over dokumentasjonen som finnes.
 
+## Samhandling
+
+- [Slack](https://ssb-norge.slack.com)
+- [GitHub](https://github.com/statisticsnorway)
+- [Confluence](https://statistics-norway.atlassian.net/wiki/home)
+- [Byrånettet](https://ssbno.sharepoint.com/sites/byraanettet)
+
 ## Plattform
 
 ### SSB Backstage

--- a/dapla-manual/utviklere/lenker.qmd
+++ b/dapla-manual/utviklere/lenker.qmd
@@ -41,7 +41,7 @@ Dokumentasjon for utviklere i SSB er spredt over mange ulike sider. Denne siden 
 
 ## Oppsett
 
-Generellt er utviklere i SSB veldig fri å velge sin lokal dev-oppsett utifra preferanser og teknologivalg. Følgende lenker går på SSB spesifikk oppsett, særlig relatert til nettverkstilgang og sikkerhet ellers.
+Generellt er utviklere i SSB veldig fri til å velge sin lokal dev-oppsett utifra preferanser og teknologivalg. Følgende lenker går på SSB spesifikk oppsett, særlig relatert til nettverkstilgang og sikkerhet ellers.
 
 - [Kundeservice FAQ](https://ssbno.sharepoint.com/sites/IT-service/SitePages/FAQ.aspx?e=VN49nD&share=Ec6hmugapi9JrCHxcgGnujkB7AVgu7SPNCIypjaoETjGQw)
     - WiFi
@@ -66,4 +66,4 @@ Generellt er utviklere i SSB veldig fri å velge sin lokal dev-oppsett utifra pr
 ## Prosess
 
 - [Operasjonell modell](https://statistics-norway.atlassian.net/wiki/spaces/A700/pages/3522494510/Operasjonell+modell+Avdeling+for+IT+-+A700)
-- [IT Avdelingens leveranse demo](https://statistics-norway.atlassian.net/wiki/spaces/A700/pages/875954203/IT+Avdelingens+leveranse+demo) (tar sted en gang i måneden på fredag)
+- [IT Avdelingens leveranse demo](https://statistics-norway.atlassian.net/wiki/spaces/A700/pages/875954203/IT+Avdelingens+leveranse+demo) (finner sted en gang i måneden på fredag)

--- a/dapla-manual/utviklere/lenker.qmd
+++ b/dapla-manual/utviklere/lenker.qmd
@@ -1,0 +1,69 @@
+# Lenker
+
+Dokumentasjon for utviklere i SSB er spredt over mange ulike sider. Denne siden er en oversikt over dokumentasjonen som finnes.
+
+## Plattform
+
+### SSB Backstage
+
+<https://backstage.intern.ssb.no>
+
+- Programvarekatalog
+- Teamkatalog
+- Teknologiradar
+
+### Nais
+
+- Offisielle docs fra nav: <https://docs.ssb.cloud.nais.io/>
+- Intern system docs: <https://psychic-broccoli-evke4lm.pages.github.io/>
+- Nais console: <https://console.ssb.cloud.nais.io/>
+
+### Dapla
+
+- Dapla ctrl (teamkatalog): <https://ctrl.dapla.ssb.no/>
+
+### Dapla Lab
+
+- <https://lab.dapla.ssb.no/>
+- Intern system docs: <https://curly-disco-j7893z3.pages.github.io/>
+- Bruker docs: <https://manual.dapla.ssb.no/statistikkere/dapla-lab.html>
+
+### Utgått
+
+- <https://docs.bip.ssb.no>
+- <https://docs.dapla.ssb.no/>
+
+## Arkitektur
+
+- [Arkitekturprinsipper](https://statistics-norway.atlassian.net/wiki/x/AYDs0g)
+- [Architecture Decision Records](https://adr.ssb.no)
+- [Teknologiradar](https://backstage.intern.ssb.no/tech-radar)
+
+## Oppsett
+
+Generellt er utviklere i SSB veldig fri å velge sin lokal dev-oppsett utifra preferanser og teknologivalg. Følgende lenker går på SSB spesifikk oppsett, særlig relatert til nettverkstilgang og sikkerhet ellers.
+
+- [Kundeservice FAQ](https://ssbno.sharepoint.com/sites/IT-service/SitePages/FAQ.aspx?e=VN49nD&share=Ec6hmugapi9JrCHxcgGnujkB7AVgu7SPNCIypjaoETjGQw)
+    - WiFi
+    - Microsoft Authenticator
+    - VPN
+    - Epost
+    - Passordbytte
+- [Git/GitHub](https://statistics-norway.atlassian.net/wiki/spaces/BEST/pages/3041493000/Hvordan-beskrivelser)
+- [IntelliJ lisenser](https://statistics-norway.atlassian.net/wiki/spaces/BEST/pages/2586050661/Verkt+y)
+- [Installer naisdevice](https://docs.ssb.cloud.nais.io/operate/naisdevice/how-to/install/)
+
+## Test og kvalitet
+
+### Tilgjengelige tjenester
+
+- [Dependabot](https://statistics-norway.atlassian.net/wiki/spaces/BEST/pages/3037626783/Sikkerhetstester+i+SSB#Dependabot)
+- [Snyk](https://statistics-norway.atlassian.net/wiki/spaces/BEST/pages/3037626783/Sikkerhetstester+i+SSB#Snyk)
+- [Detectify](https://statistics-norway.atlassian.net/wiki/spaces/BEST/pages/3037626783/Sikkerhetstester+i+SSB#Detectify)
+- [Sonarcloud](https://statistics-norway.atlassian.net/wiki/spaces/BEST/pages/3565748420/SonarCloud+kodekvalitetsverkt+y)
+- [Mabl]()
+
+## Prosess
+
+- [Operasjonell modell](https://statistics-norway.atlassian.net/wiki/spaces/A700/pages/3522494510/Operasjonell+modell+Avdeling+for+IT+-+A700)
+- [IT Avdelingens leveranse demo](https://statistics-norway.atlassian.net/wiki/spaces/A700/pages/875954203/IT+Avdelingens+leveranse+demo) (tar sted en gang i måneden på fredag)

--- a/dapla-manual/utviklere/lenker.qmd
+++ b/dapla-manual/utviklere/lenker.qmd
@@ -15,7 +15,7 @@ Dokumentasjon for utviklere i SSB er spredt over mange ulike sider. Denne siden 
 ### Nais
 
 - Offisielle docs fra nav: <https://docs.ssb.cloud.nais.io/>
-- Intern system docs: <https://psychic-broccoli-evke4lm.pages.github.io/>
+- Intern system docs: <https://statisticsnorway.github.io/nais-system>
 - Nais console: <https://console.ssb.cloud.nais.io/>
 
 ### Dapla
@@ -25,8 +25,8 @@ Dokumentasjon for utviklere i SSB er spredt over mange ulike sider. Denne siden 
 ### Dapla Lab
 
 - <https://lab.dapla.ssb.no/>
-- Intern system docs: <https://curly-disco-j7893z3.pages.github.io/>
-- Bruker docs: <https://manual.dapla.ssb.no/statistikkere/dapla-lab.html>
+- Intern system docs: <https://statisticsnorway.github.io/dapla-lab-system>
+- Brukerdokumentasjon: <https://manual.dapla.ssb.no/statistikkere/dapla-lab.html>
 
 ### Utgått
 


### PR DESCRIPTION
## Oppsummering

Første siden for utviklermanualen er en samleside for å finne fram til eksisterende dok. Det legges til flere sider på ulike temaer etterhvert.

## Skjermdump

<img width="1779" alt="Screenshot 2024-10-04 at 09 08 48" src="https://github.com/user-attachments/assets/cd8cd87d-591f-4234-864d-738c37a0cb92">
