### PR TITLE
Update URLs and code samples to point at Maskinporten Guardian in NAIS

### DIFF
--- a/dapla-manual/statistikkere/maskinporten-guardian.qmd
+++ b/dapla-manual/statistikkere/maskinporten-guardian.qmd
@@ -102,6 +102,10 @@ Man skal i hovedsak kun anvende M2M-brukere for datautveksling mot API-er som er
 skal kun brukes unntaksvis for enkeltoppslag (f. eks ved feilsøking) mot API-er eller for utvikling og test.
 :::
 
+Legg merke til at Maskinporten Guardian kun er tilgjengelig fra interne SSB-adresser. Bruk følgende URL-er:
+* Prod: `https://guardian.intern.ssb.no`
+* Test: `https://guardian.intern.test.ssb.no`
+
 ## Systemskisse
 
 Følgende gir en oversikt over hvordan systemer henger sammen. En API-konsument kan f. eks være et Dapla-team som ønsker å hente data,
@@ -198,7 +202,7 @@ with contents such as:
 
 keycloak_url = "https://auth.test.ssb.no"
 keycloak_clients_gcp_project_id = "keycloak-clients-<p|t>-??"
-guardian_url = "https://guardian.dapla-staging.ssb.no"
+guardian_url = "https://guardian.intern.test.ssb.no"
 
 [my-api]
     maskinporten_client_id = "12345678-9abc-def0-1234-567890abcdef"
@@ -289,7 +293,7 @@ The following code example expects a toml config file to exist named
 
 with contents such as:
 
-guardian_url = "https://guardian.dapla-staging.ssb.no"
+guardian_url = "https://guardian.intern.test.ssb.no"
 
 [my-api]
     maskinporten_client_id = "12345678-9abc-def0-1234-567890abcdef"


### PR DESCRIPTION
Maskinporten Guardian in NAIS is now preferred. Update the code samples to reflect this:

* Prod: `https://guardian.intern.ssb.no`
* Test: `https://guardian.intern.test.ssb.no`
