### PR TITLE
News turning off jupyter

### DIFF
--- a/dapla-manual/news/posts/2024-11-25-referansegruppe-dapla-lab/index.qmd
+++ b/dapla-manual/news/posts/2024-11-25-referansegruppe-dapla-lab/index.qmd
@@ -1,6 +1,5 @@
 ---
 title: Når skrus 'gamle' jupyter av?
-subtitle: Referansegruppe for statistikktjenester
 categories:
   - Dapla Lab
   - Jupyter
@@ -15,8 +14,8 @@ date-modified: "11/25/2024"
 draft: false
 ---
 
-[Forrige DaplaNytt](../2024-11-20-daplanytt-nov/index.qmd) ble 15. januar 2025 nevt som en mulig sluttdato for 'gamle' jupyter, altså [https://jupyter.dapla.ssb.no](https://jupyter.dapla.ssb.no), og dered en endelig overgang til Dapla Lab.
+Under [forrige DaplaNytt](../2024-11-20-daplanytt-nov/index.qmd) ble 15. januar 2025 nevt som en mulig sluttdato for 'gamle' jupyter, altså [https://jupyter.dapla.ssb.no](https://jupyter.dapla.ssb.no), og dermed en endelig overgang til Dapla Lab.
 
-Denne datoen er tentativ. Sluttdato for gamle jupyter vil bli endeliggjort etter møtet med referansegruppen for statistikktjenester 6. desember 2024. Referansegruppen har representanter fra hver statistikkavdeling.
+**Denne datoen er tentativ**. Sluttdato for gamle jupyter vil bli endeliggjort etter møtet med referansegruppen for statistikktjenester 6. desember 2024. Referansegruppen har representanter fra hver statistikkavdeling.
 
 I mellomtiden ber vi brukere om å henvende seg til sine respektive støtteteam, nærmeste leder eller medlemmene av referansegruppen for innvendinger eller innspill til når vi kan gjennomføre en endelig overgang til Dapla Lab.

--- a/dapla-manual/news/posts/2024-11-25-referansegruppe-dapla-lab/index.qmd
+++ b/dapla-manual/news/posts/2024-11-25-referansegruppe-dapla-lab/index.qmd
@@ -1,0 +1,22 @@
+---
+title: Når skrus 'gamle' jupyter av?
+subtitle: Referansegruppe for statistikktjenester
+categories:
+  - Dapla Lab
+  - Jupyter
+  - referansegruppe
+author:
+  - name: Alex Crozier
+    affiliation: 
+      - name: A200 Støtteteam
+        email: akc@ssb.no
+date: "11/25/2024"
+date-modified: "11/25/2024"
+draft: false
+---
+
+[Forrige DaplaNytt](../2024-11-20-daplanytt-nov/index.qmd) ble 15. januar 2025 nevt som en mulig sluttdato for 'gamle' jupyter, altså [https://jupyter.dapla.ssb.no](https://jupyter.dapla.ssb.no), og dered en endelig overgang til Dapla Lab.
+
+Denne datoen er tentativ. Sluttdato for gamle jupyter vil bli endeliggjort etter møtet med referansegruppen for statistikktjenester 6. desember 2024. Referansegruppen har representanter fra hver statistikkavdeling.
+
+I mellomtiden ber vi brukere om å henvende seg til sine respektive støtteteam, nærmeste leder eller medlemmene av referansegruppen for innvendinger eller innspill til når vi kan gjennomføre en endelig overgang til Dapla Lab.


### PR DESCRIPTION
En liten nyhetssak om når gamle jupyter skrus av (og hva prosessen er).

I  statistikkavdelingene ryktes det om at 15 januar er en endelig sluttdato. Innlegget har som hensikt å rydde opp i dette.

#172 