### PR TITLE
Fix filepaths to images that don't render

### DIFF
--- a/dapla-manual/statistikkere/git-og-github.qmd
+++ b/dapla-manual/statistikkere/git-og-github.qmd
@@ -117,7 +117,7 @@ Slik gjør du det:
 2.  Trykk **Sign up** øverst i høyre hjørne
 3.  I dialogboksen som åpnes, se @fig-GitHub-user-gen, skriver du inn din e-postkonto og lager et passord. Dette trenger ikke være din SSB-bruker og e-post. Vi anbefaler at du bruker en personlig e-postkonto og velger ditt eget passord. Det samme gjelder **brukernavn** også.
 
-![Dialogboks for opprettelse av GitHub-bruker.](../images/GitHub_register.JPG){#fig-GitHub-user-gen fig-alt="Bilde av GitHub-siden for å generere en brukerkonto"}
+![Dialogboks for opprettelse av GitHub-bruker.](../images/github_register.JPG){#fig-GitHub-user-gen fig-alt="Bilde av GitHub-siden for å generere en brukerkonto"}
 
 Du har nå laget en egen GitHub-bruker. I neste steg skal vi knytte denne kontoen til din SSB-bruker.
 
@@ -125,7 +125,7 @@ Du har nå laget en egen GitHub-bruker. I neste steg skal vi knytte denne kontoe
 
 Hvis du har fullført forrige steg så har du nå en GitHub-konto. Hvis du står på din profil-side så ser den ut som i @fig-GitHub-exmaple-userpage.
 
-![Et eksempel på hjemmeområdet til en GitHub-bruker](../images/GitHub_profile.png){#fig-GitHub-exmaple-userpage fig-alt="Bilde av GitHub-siden for en bruker"}
+![Et eksempel på hjemmeområdet til en GitHub-bruker](../images/github_profile.png){#fig-GitHub-exmaple-userpage fig-alt="Bilde av GitHub-siden for en bruker"}
 
 Det neste vi må gjøre er å aktivere 2-faktor autentisering, siden det er dette som benyttes i SSB. Hvis du står på siden i bildet over, så gjør du følgende for å aktivere 2-faktor autentisering mot GitHub:
 
@@ -139,13 +139,13 @@ Det neste vi må gjøre er å aktivere 2-faktor autentisering, siden det er dett
 :::
 
 ::: g-col-4
-![Åpne settings for din GitHub-bruker.](../images/GitHub_settings_menu.png){#fig-GitHub-open-settings fig-alt="Bilde av GitHub-menyen for å åpne Settings-menyen." width="50%"}
+![Åpne settings for din GitHub-bruker.](../images/github_settings_menu.png){#fig-GitHub-open-settings fig-alt="Bilde av GitHub-menyen for å åpne Settings-menyen." width="50%"}
 :::
 :::
 
 4.  @fig-GitHub-enable-2fa viser dialogboksen som vises. Velg **Enable two-factor authentification**.
 
-![Dialogboks som åpnes når 2FA skrus på første gang.](../images/GitHub_2fa_enable.JPG){#fig-GitHub-enable-2fa fig-alt="Bilde av GitHub-dialogboks for å skru på 2-faktor autentisering."}
+![Dialogboks som åpnes når 2FA skrus på første gang.](../images/github_2fa_enable.JPG){#fig-GitHub-enable-2fa fig-alt="Bilde av GitHub-dialogboks for å skru på 2-faktor autentisering."}
 
 5.  @fig-GitHub-2fa-app viser dialogboksen som vises for å velge hvordan man skal autentisere seg. Her anbefales det å velge **Set up using an app**, slik at du kan bruke *Microsoft Authenticator*-appen på din mobil.
 
@@ -153,7 +153,7 @@ Det neste vi må gjøre er å aktivere 2-faktor autentisering, siden det er dett
 
 @fig-GitHub-QR viser QR-koden som vises. Denne skal vi bruke i neste steg.
 
-![QR-kode som skannes av Microsoft Authenticator.](../images/GitHub_2fa.png){#fig-GitHub-QR fig-alt="Bilde av GitHub-dialogboks for å velge hvordan man skal autentisere seg med 2-faktor autentisering."}
+![QR-kode som skannes av Microsoft Authenticator.](../images/github_2fa.png){#fig-GitHub-QR fig-alt="Bilde av GitHub-dialogboks for å velge hvordan man skal autentisere seg med 2-faktor autentisering."}
 
 ::: grid
 ::: g-col-8
@@ -178,11 +178,11 @@ I forrige steg aktiverte vi 2-faktor autentisering for GitHub. Det neste vi må 
 1.  Trykk på lenken <https://GitHub.com/orgs/statisticsnorway/sso>
 2.  I dialogboksen som dukker opp trykker du på **Continue**, slik som vist i @fig-GitHub-sso.
 
-![Single Sign on (SSO) for SSB sin organisasjon på GitHub](../images/GitHub_sso.png){#fig-GitHub-sso fig-alt="Bilde av GitHub-dialogboks for single sign on."}
+![Single Sign on (SSO) for SSB sin organisasjon på GitHub](../images/github_sso.png){#fig-GitHub-sso fig-alt="Bilde av GitHub-dialogboks for single sign on."}
 
 Når du har gjennomført dette så har du tilgang til **statisticsnorway** på GitHub. Går du inn på [denne lenken](https://GitHub.com/statisticsnorway?view_as=member) så skal du nå kunne lese både **Public**, **Private** og **Internal** repoer, slik som vist i @fig-GitHub-member.
 
-![Medlemsvisning for SSB sin GitHub-organisasjon.](../images/GitHub_asmember.png){#fig-GitHub-member fig-alt="Bilde av repoene på GitHub for de som er tilknyttet staitsticsnorway."}
+![Medlemsvisning for SSB sin GitHub-organisasjon.](../images/github_asmember.png){#fig-GitHub-member fig-alt="Bilde av repoene på GitHub for de som er tilknyttet staitsticsnorway."}
 
 ### Personal Access Token (PAT)
 
@@ -206,17 +206,17 @@ For å lage en PAT som er godkjent mot *statisticsnorway* så gjør man følgend
 
 7.  Under **Select scopes** velger du **repo** og **workflow** slik som vist i @fig-GitHub-token.
 
-![Gi token et kort og beskrivende navn](../images/GitHub_pat.png){#fig-GitHub-token fig-alt="Bilde av GitHub-siden for generering av Personal Access Token"}
+![Gi token et kort og beskrivende navn](../images/github_pat.png){#fig-GitHub-token fig-alt="Bilde av GitHub-siden for generering av Personal Access Token"}
 
 8.  Trykk på **Generate token** nederst på siden og du får noe lignende det du ser i @fig-GitHub-token-gen.
 
-![Token som ble generert.](../images/GitHub_pat2.png){#fig-GitHub-token-gen fig-alt="Bilde av GitHub-siden for det genererte tokenet"}
+![Token som ble generert.](../images/github_pat2.png){#fig-GitHub-token-gen fig-alt="Bilde av GitHub-siden for det genererte tokenet"}
 
 9.  Kopier deretter PAT til en midlertidig fil. Grunnen er at du aldri vil se det igjen her etter at vi har gjennomført neste steg.
 
 10. Deretter trykker du på **Configure SSO** og velger **Authorize** ved siden statisticsnorway, slik som vist i @fig-GitHub-token-authorize. Svar deretter på spørsmålene som dukker opp.
 
-![Autorisering av Token mot SSBs GiHub-organisasjon.](../images/GitHub_pat3.png){#fig-GitHub-token-authorize fig-alt="Bilde av GitHub-siden for å autorisere Token mot statisticsnorway"}
+![Autorisering av Token mot SSBs GiHub-organisasjon.](../images/github_pat3.png){#fig-GitHub-token-authorize fig-alt="Bilde av GitHub-siden for å autorisere Token mot statisticsnorway"}
 
 Vi har nå opprettet en PAT som er godkjent for bruk mot SSB sin kode på GitHub. Det betyr at hvis vi vil jobbe med **Git** på SSB sine maskiner i sky eller på bakken, så må vi sendte med dette tokenet for å få lov til å jobbe med koden som ligger på **statisticsnorway** på GitHub.
 


### PR DESCRIPTION
Fix casing of image paths which made images not render. For some reason this still rendered properly in `quarto preview` and even when hosting n http server with the rendered HTML file from `quarto render`, but when hosted on gh-pages you get 404s for the uppercased filepaths which makes sense as they don't exist:

![image](https://github.com/user-attachments/assets/1fbf7fad-6afb-421e-99d2-bf71d8bf3c1c)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-manual/178)
<!-- Reviewable:end -->
