### PR TITLE
Skrivefeil: jupyter.qmd

### DIFF
--- a/dapla-manual/statistikkere/jupyter.qmd
+++ b/dapla-manual/statistikkere/jupyter.qmd
@@ -56,7 +56,7 @@ I @fig-dapla-lab-konf-pyr ser vi av navnet r4.4.0-py311-v55-2024.10.31 at tjenes
 
 ### Ressurser
 
-Under menyen **Resources** kan man velge hvor mye CPU og RAM man ønsker i tjenesten, slik som vist i @fig-dapla-lab-resources. Velg så lite treng for ås gjøre jobben du skal gjøre. 
+Under menyen **Resources** kan man velge hvor mye CPU og RAM man ønsker i tjenesten, slik som vist i @fig-dapla-lab-resources. Velg så lite som trengs for å gjøre jobben du skal gjøre. 
 
 ![Konfigurasjon av ressurser for Jupyter-tjenesten i Dapla Lab](../images/dapla-lab-resources.png){fig-alt="Viser Resources-fanen i Jupyter-konfigurasjonen i Dapla Lab." #fig-dapla-lab-resources}
 


### PR DESCRIPTION
Fant noe jeg antar er en skrivefeil i avsnitt om konfigurasjon av Jupyter i dapla-lab. Endret fra "Velg så lite treng for ås gjøre jobben ..." Til "Velg så lite som trengs for å gjøre jobben ..."

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-manual/183)
<!-- Reviewable:end -->
