### PR TITLE
Fix: outdated link updated

### DIFF
--- a/dapla-manual/statistikkere/standarder.qmd
+++ b/dapla-manual/statistikkere/standarder.qmd
@@ -68,7 +68,7 @@ Standardutvalget har *ikke* ansvar for standarder innenfor koding og statistiske
 
 ##### 5. **Navnestandard** for henholdsvis:
 
-* Enhetstypeidentifikatorer - [DM-vedtak (internet dokument)](https://ssbno.sharepoint.com/sites/A20-Standardutvalget/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2FA20%2DStandardutvalget%2FShared%20Documents%2FGeneral%2FM%C3%B8ter%2F20221201%2F2023%2D1%5FDM%2Dgodkj%2DEnhetstypeIDnavn%2Epdf&parent=%2Fsites%2FA20%2DStandardutvalget%2FShared%20Documents%2FGeneral%2FM%C3%B8ter%2F20221201)
+* Enhetstypeidentifikatorer - [DM-vedtak (internet dokument)](https://ssbno.sharepoint.com/sites/A20-Standardutvalget/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2FA20%2DStandardutvalget%2FShared%20Documents%2FGeneral%2FM%C3%B8ter%2F2022%2F20221201%2F2023%2D1%5FDM%2Dgodkj%2DEnhetstypeIDnavn%2Epdf&parent=%2Fsites%2FA20%2DStandardutvalget%2FShared%20Documents%2FGeneral%2FM%C3%B8ter%2F2022%2F20221201)
 * GitHub repoer - [Internt dokument](https://ssbno.sharepoint.com/:w:/r/sites/A20-Standardutvalget/_layouts/15/Doc.aspx?sourcedoc=%7BC20FDE49-C24A-49C5-A9AB-4251DE8EAE16%7D&file=Navnestandard_for_GitHub_repoer_oppdatert_endelig.docx&action=default&mobileredirect=true)
 * Nøkkelvariabler (*anbefaling*) - [Byrånettside](https://ssbno.sharepoint.com/sites/Avdelingerutvalgograd/SitePages/Vedtak-fra-Standardutvalget.aspx#standardnavn-for-n%C3%B8kkelvariabler)
 * Datasett - [Dapla-manualen: Navnestandard (og versjonering)](navnestandard.qmd)


### PR DESCRIPTION
New link for Enhetstypeidentifikatorer pkt. 5 in Standarder updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-manual/239)
<!-- Reviewable:end -->
