### PR TITLE
fix dapla-auth-client typo in example code

### DIFF
--- a/dapla-manual/blog/posts/2025-06-12-dapla-auth-client/index.qmd
+++ b/dapla-manual/blog/posts/2025-06-12-dapla-auth-client/index.qmd
@@ -37,7 +37,7 @@ I dette blogginnlegget presenterer vi endringen der autentiseringsklassen er fly
 
 ```python
 from google.cloud import storage
-from dapla.auth import AuthClient
+from dapla import AuthClient
 
 storage_client = storage.Client(
     credentials=AuthClient.fetch_google_credentials()
@@ -69,7 +69,7 @@ poetry add dapla-auth-client
 Dersom du tidligere importerte slik:
 
 ```python
-from dapla.auth import AuthClient
+from dapla import AuthClient
 ```
 
 bytter du til:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-manual/369)
<!-- Reviewable:end -->
