### PR TITLE
Hyperlink fixes

### DIFF
--- a/dapla-manual/statistikkere/dapla-pseudo.qmd
+++ b/dapla-manual/statistikkere/dapla-pseudo.qmd
@@ -62,7 +62,7 @@ I denne delen viser vi hvilken funksjonalitet som tilbys gjennom dapla-toolbelt-
 
 ### Installering
 
-[dapla-toolbelt-pseudo](https://pypi.org/project/dapla-toolbelt-pseudo/) er ferdig installert i Kildomaten. Men ønsker du å bruke den i test-miljøet til teamet så kan du installere det i et [ssb-project](./jobbe-med-kode.html) fra [PyPI](https://pypi.org/) med denne kommandoen: 
+[dapla-toolbelt-pseudo](https://pypi.org/project/dapla-toolbelt-pseudo/) er ferdig installert i Kildomaten. Men ønsker du å bruke den i test-miljøet til teamet så kan du installere det i et [ssb-project](./ssb-project.html) fra [PyPI](https://pypi.org/) med denne kommandoen: 
 
 ```{.bash filename="Terminal"}
 poetry add dapla-toolbelt-pseudo

--- a/dapla-manual/statistikkere/dapla-pseudo.qmd
+++ b/dapla-manual/statistikkere/dapla-pseudo.qmd
@@ -62,7 +62,7 @@ I denne delen viser vi hvilken funksjonalitet som tilbys gjennom dapla-toolbelt-
 
 ### Installering
 
-[dapla-toolbelt-pseudo](https://pypi.org/project/dapla-toolbelt-pseudo/) er ferdig installert i Kildomaten. Men ønsker du å bruke den i test-miljøet til teamet så kan du installere det i et [ssb-project](./ssb-project.html) fra [PyPI](https://pypi.org/) med denne kommandoen: 
+[dapla-toolbelt-pseudo](https://pypi.org/project/dapla-toolbelt-pseudo/) er ferdig installert i Kildomaten. Men ønsker du å bruke den i test-miljøet til teamet så kan du installere det i et [ssb-project](./ssb-project.qmd) fra [PyPI](https://pypi.org/) med denne kommandoen: 
 
 ```{.bash filename="Terminal"}
 poetry add dapla-toolbelt-pseudo

--- a/dapla-manual/statistikkere/gcc.qmd
+++ b/dapla-manual/statistikkere/gcc.qmd
@@ -7,7 +7,7 @@ lightbox: true
 ---
 
 ---
-title: "Anbefalt arbeidsflyt med Git"
+title: "Google Cloud Console (GCC)"
 
 lightbox: true
 ---

--- a/dapla-manual/statistikkere/poetry-ssb-project.qmd
+++ b/dapla-manual/statistikkere/poetry-ssb-project.qmd
@@ -87,7 +87,7 @@ Det vil gi en grafisk fremstilling av avhengighetene som vist i @fig-ssb-proj-tr
 
 ## Push til GitHub
 
-Når du nå har installert en pakke så har filen **poetry.lock** endret seg. For at dine samarbeidspartnere skal få tilgang til denne endringen i et SSB-project, så må du pushe en ny versjon av poetry.lock-filen opp Github, og kollegaene må pulle ned og [bygge prosjektet på nytt](./jobbe-med-kode.html#bygg-eksisterende-ssb-project). Du kan gjøre dette på følgende måte etter at du har installert en ny pakke:
+Når du nå har installert en pakke så har filen **poetry.lock** endret seg. For at dine samarbeidspartnere skal få tilgang til denne endringen i et SSB-project, så må du pushe en ny versjon av poetry.lock-filen opp Github, og kollegaene må pulle ned og [bygge prosjektet på nytt](./ssb-project.html#bygg-eksisterende-ssb-project). Du kan gjøre dette på følgende måte etter at du har installert en ny pakke:
 
 1. Vi kan *stage* alle endringer med følgende kommando i terminalen når vi står i prosjektmappen:
 

--- a/dapla-manual/statistikkere/poetry-ssb-project.qmd
+++ b/dapla-manual/statistikkere/poetry-ssb-project.qmd
@@ -87,7 +87,7 @@ Det vil gi en grafisk fremstilling av avhengighetene som vist i @fig-ssb-proj-tr
 
 ## Push til GitHub
 
-Når du nå har installert en pakke så har filen **poetry.lock** endret seg. For at dine samarbeidspartnere skal få tilgang til denne endringen i et SSB-project, så må du pushe en ny versjon av poetry.lock-filen opp Github, og kollegaene må pulle ned og [bygge prosjektet på nytt](./ssb-project.html#bygg-eksisterende-ssb-project). Du kan gjøre dette på følgende måte etter at du har installert en ny pakke:
+Når du nå har installert en pakke så har filen **poetry.lock** endret seg. For at dine samarbeidspartnere skal få tilgang til denne endringen i et SSB-project, så må du pushe en ny versjon av poetry.lock-filen opp Github, og kollegaene må pulle ned og [bygge prosjektet på nytt](./ssb-project.qmd#bygg-eksisterende-ssb-project). Du kan gjøre dette på følgende måte etter at du har installert en ny pakke:
 
 1. Vi kan *stage* alle endringer med følgende kommando i terminalen når vi står i prosjektmappen:
 


### PR DESCRIPTION
Minor fixes:

1. Fixed hyperlink addresses in articles on [pseudonymization](https://manual.dapla.ssb.no/statistikkere/dapla-pseudo.html) and [package management](https://manual.dapla.ssb.no/statistikkere/poetry-ssb-project.html) to properly point to the article on [ssb-project cli](https://manual.dapla.ssb.no/statistikkere/ssb-project.html)
2. Fixed title in the article on [Google Cloud Console](https://manual.dapla.ssb.no/statistikkere/gcc.html) which title erroneously referred to [Git arbeidsflyt](https://manual.dapla.ssb.no/statistikkere/git-arbeidsflyt.html)

Another bug that occurred when open this pull request is the automatic message:

> Har du husket å lese gjennom [retningslinjene for å bidra til manualen]()?

which hyperlink ought to point to `https://manual.dapla.ssb.no/statistikkere/appendix/contribution.html` and not `dapla-manual/statistikkere/appendix/contribution.qml` as it currently does.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-manual/455)
<!-- Reviewable:end -->
