### PR TITLE
Added ssb-gcp-identity-client.qmd

### DIFF
--- a/dapla-manual/_quarto.yml
+++ b/dapla-manual/_quarto.yml
@@ -169,6 +169,7 @@ website:
             - statistikkere/metodebibliotek.qmd
             - statistikkere/gcc.qmd
             - statistikkere/ssb-altinn-python.qmd
+            - statistikkere/ssb-gcp-identity-client.qmd
         - section: "Altinn 3"
           href: statistikkere/altinn-oversikt.qmd
           contents:

--- a/dapla-manual/statistikkere/maskinporten-guardian.qmd
+++ b/dapla-manual/statistikkere/maskinporten-guardian.qmd
@@ -174,6 +174,31 @@ I test skal `maskinporten_audience` ha verdien `https://test.maskinporten.no/`.
 I prod skal det være `https://maskinporten.no/` (merk: skråstrek på slutten er viktig)
 :::
 
+### Skyporten eksempelkonfigurasjon
+
+```text
+amends ".../pkl/MaskinportenGuardianClient.pkl"
+
+api_shortname = "Kort API-beskrivelse (maks 32 tegn)"
+ maskinporten_client_id = "12345678-9abc-def0-1234-567890abcdef"
+ maskinporten_audience = "https://maskinporten.no/"
+ maskinporten_default_scopes {
+   "foo:data1"
+   "foo:data2"
+ }
+ credentials_access {
+   "group:play-foeniks-data-admins@groups.ssb.no"
+   "serviceaccount:foo-sa@play-foeniks-p-ab.iam.gserviceaccount.com"
+ }
+
+mappers {
+  new HardcodedClaimMapper {
+    claim_name = "skyporten_audience"
+    claim_value = "https://sky.maskinporten.no"
+  }
+}
+```
+
 Pull Requesten må godkjennes og behandles av en Dapla platformutvikler. Når dette er gjort blir det opprettet en Keycloak-klient, og hemmeligheten
 som kan brukes for å hente ut sikkerhetstokens for denne klienten er tilgjengelig i Secret Manager.
 
@@ -244,6 +269,21 @@ response = requests.post(f"{config['keycloak_url']}/realms/ssb/protocol/openid-c
 keycloak_access_token = response.json()['access_token']
 
 # Get Maskinporten access token from Maskinporten Guardian (using the Keycloak token from above)
+
+# If user want access to data from external resources via skyporten they need extra parameter in the request:
+
+# Audience (aud) is a claim in a token that tells which service the token is intended for.
+
+# In this case, the token is meant to be used with Skyporten, a service hosted by Kartverket (Norwegian Mapping Authority).
+
+# So, "https://skyporten.kartverk.no" is the identifier of the target service that will receive and validate the token.
+
+
+request_body={
+    "accessTokenAudience" : "https://skyporten.kartverk.no",
+ }
+
+
 # Note that you can specify custom scopes in the request body if you need to. Using defaults defined in the client config if not specified.
 request_body={}
 response = requests.post(f"{config['guardian_url']}/maskinporten/access-token",

--- a/dapla-manual/statistikkere/ssb-gcp-identity-client.qmd
+++ b/dapla-manual/statistikkere/ssb-gcp-identity-client.qmd
@@ -17,8 +17,8 @@ poetry add ssb-gcp-identity-client
 
 ## Maskinporten-tokens
 
-Når du skal autentisere deg mot Skyporten må du først hente ut en gyldig Maskinporten-token.
-For mer informasjon om Maskinporten-tokens se [Maskinporten-dokumentasjonen](./maskinporten-guardian.qmd).
+Når du skal autentisere deg mot Skyporten må du først hente ut et gyldig Maskinporten-token.
+Se [Maskinporten-dokumentasjonen](./maskinporten-guardian.qmd) for mer informasjon.
 
 ## Funksjonalitet
 
@@ -27,7 +27,7 @@ For mer informasjon om Maskinporten-tokens se [Maskinporten-dokumentasjonen](./m
 Funksjonen `get_federated_storage_client()` returnerer en Google Cloud Storage-klient autentisert gjennom Skyporten,
 som kan brukes mot bøtter i eksterne Google Cloud prosjekter.
 
-Funksjonen tar inn parametre som identifiserer den eksterne aktørens Workload Identity-pool, samt Maskinporten-tokenet som en streng.
+Funksjonen tar inn parametre som identifiserer den eksterne aktørens Workload Identity-pool samt Maskinporten-tokenet som en streng.
 
 ```{.python}
 from ssb_gcp_identity_client import get_federated_storage_client
@@ -50,7 +50,7 @@ Funksjonen `get_federated_credentials()` returnerer Google Cloud-credentials aut
 som kan brukes til å opprette Google Cloud-klienter. Funksjonen er nyttig dersom man ønsker å opprette klienter av
 andre typer enn Storage.
 
-Funksjonen tar inn parametre som identifiserer den eksterne aktørens Workload Identity-pool, samt Maskinporten-tokenet som en streng.
+Funksjonen tar inn parametre som identifiserer den eksterne aktørens Workload Identity-pool samt Maskinporten-tokenet som en streng.
 
 ```{.python}
 from ssb_gcp_identity_client import get_federated_credentials
@@ -70,5 +70,5 @@ for bucket in storage_client.list_buckets():
 
 ## Andre ressurser
 
-Se [kode-repoet](https://github.com/statisticsnorway/ssb-gcp-identity-client) og [dokumentasjonen](https://congenial-carnival-ezl841m.pages.github.io/reference.html)
+Se [koden](https://github.com/statisticsnorway/ssb-gcp-identity-client) og [dokumentasjonen](https://congenial-carnival-ezl841m.pages.github.io/reference.html)
 for ssb-gcp-identity-client på Github.

--- a/dapla-manual/statistikkere/ssb-gcp-identity-client.qmd
+++ b/dapla-manual/statistikkere/ssb-gcp-identity-client.qmd
@@ -1,0 +1,74 @@
+---
+title: "ssb-gcp-identity-client"
+date-modified: "21/10/2025"
+lightbox: true
+---
+
+[ssb-gcp-identity-client](https://pypi.org/project/ssb-gcp-identity-client/) er en Python-pakke med funksjonalitet for
+å koble seg til eksterne Google Cloud skyressurser med Maskinporten-tokens gjennom [Skyporten](https://docs.digdir.no/docs/Maskinporten/maskinporten_skyporten.html/).
+
+## Installasjon
+
+For å benytte [ssb-gcp-identity-client](https://pypi.org/project/ssb-gcp-identity-client/) må man først installere pakken i et [ssb-project](./ssb-project.qmd):
+
+```{.bash filename="Terminal"}
+poetry add ssb-gcp-identity-client
+```
+
+## Maskinporten-tokens
+
+Før du kan autentisere deg mot Skyporten må du hente ut en gyldig Maskinporten-token og lagre den som en .txt-fil i Jupyter-miljøet.
+For mer informasjon om Maskinporten-tokens se [Maskinporten-dokumentasjonen](./maskinporten-guardian.qmd).
+
+## Funksjonalitet
+
+### get_federated_storage_client()
+
+Funksjonen `get_federated_storage_client()` returnerer en Google Cloud Storage-klient autentisert gjennom Skyporten,
+som kan brukes mot bøtter i eksterne Google Cloud prosjekter.
+
+Funksjonen tar inn fire parametre som identifiserer den eksterne aktørens Workload Identity-pool, samt filstien til Maskinporten-tokenet.
+
+```{.python}
+from ssb_gcp_identity_client import get_federated_storage_client
+
+storage_client = get_federated_storage_client(
+    project_number="1234567890",
+    workload_identity_pool_id="my-pool",
+    provider_id="maskinporten-provider",
+    maskinporten_token_file_path="~/tokens/maskinporten_access_token.txt"
+)
+
+# Eksempel på bruk av klienten
+for bucket in storage_client.list_buckets():
+    print(bucket.name)
+```
+
+### get_federated_credentials()
+
+Funksjonen `get_federated_credentials()` returnerer Google Cloud-credentials autentisert gjennom Skyporten,
+som kan brukes til å opprette Google Cloud-klienter. Funksjonen er nyttig dersom man ønsker å opprette klienter av
+andre typer enn Storage.
+
+Funksjonen tar inn fire parametre som identifiserer den eksterne aktørens Workload Identity-pool, samt filstien til Maskinporten-tokenet.
+
+```{.python}
+from ssb_gcp_identity_client import get_federated_credentials
+
+creds = get_federated_credentials(
+    project_number="1234567890",
+    workload_identity_pool_id="my-pool",
+    provider_id="maskinporten-provider",
+    maskinporten_token_file_path="~/tokens/maskinporten_access_token.txt"
+)
+
+# Eksempel på bruk av credentials
+storage_client = storage.Client(credentials=creds)
+for bucket in storage_client.list_buckets():
+    print(bucket.name)
+```
+
+## Andre ressurser
+
+Se [kode-repoet](https://github.com/statisticsnorway/ssb-gcp-identity-client) og [dokumentasjonen](https://congenial-carnival-ezl841m.pages.github.io/reference.html)
+for ssb-gcp-identity-client på Github.

--- a/dapla-manual/statistikkere/ssb-gcp-identity-client.qmd
+++ b/dapla-manual/statistikkere/ssb-gcp-identity-client.qmd
@@ -17,7 +17,7 @@ poetry add ssb-gcp-identity-client
 
 ## Maskinporten-tokens
 
-Før du kan autentisere deg mot Skyporten må du hente ut en gyldig Maskinporten-token og lagre den som en .txt-fil i Jupyter-miljøet.
+Når du skal autentisere deg mot Skyporten må du først hente ut en gyldig Maskinporten-token.
 For mer informasjon om Maskinporten-tokens se [Maskinporten-dokumentasjonen](./maskinporten-guardian.qmd).
 
 ## Funksjonalitet
@@ -27,7 +27,7 @@ For mer informasjon om Maskinporten-tokens se [Maskinporten-dokumentasjonen](./m
 Funksjonen `get_federated_storage_client()` returnerer en Google Cloud Storage-klient autentisert gjennom Skyporten,
 som kan brukes mot bøtter i eksterne Google Cloud prosjekter.
 
-Funksjonen tar inn fire parametre som identifiserer den eksterne aktørens Workload Identity-pool, samt filstien til Maskinporten-tokenet.
+Funksjonen tar inn parametre som identifiserer den eksterne aktørens Workload Identity-pool, samt Maskinporten-tokenet som en streng.
 
 ```{.python}
 from ssb_gcp_identity_client import get_federated_storage_client
@@ -36,7 +36,7 @@ storage_client = get_federated_storage_client(
     project_number="1234567890",
     workload_identity_pool_id="my-pool",
     provider_id="maskinporten-provider",
-    maskinporten_token_file_path="~/tokens/maskinporten_access_token.txt"
+    maskinporten_token=token_as_string
 )
 
 # Eksempel på bruk av klienten
@@ -50,7 +50,7 @@ Funksjonen `get_federated_credentials()` returnerer Google Cloud-credentials aut
 som kan brukes til å opprette Google Cloud-klienter. Funksjonen er nyttig dersom man ønsker å opprette klienter av
 andre typer enn Storage.
 
-Funksjonen tar inn fire parametre som identifiserer den eksterne aktørens Workload Identity-pool, samt filstien til Maskinporten-tokenet.
+Funksjonen tar inn parametre som identifiserer den eksterne aktørens Workload Identity-pool, samt Maskinporten-tokenet som en streng.
 
 ```{.python}
 from ssb_gcp_identity_client import get_federated_credentials
@@ -59,7 +59,7 @@ creds = get_federated_credentials(
     project_number="1234567890",
     workload_identity_pool_id="my-pool",
     provider_id="maskinporten-provider",
-    maskinporten_token_file_path="~/tokens/maskinporten_access_token.txt"
+    maskinporten_token=token_as_string
 )
 
 # Eksempel på bruk av credentials


### PR DESCRIPTION
🤖 Automatisk beskjed 🤖

Har du husket å lese gjennom [retningslinjene for å bidra til manualen](dapla-manual/statistikkere/appendix/contribution.qml)?
👉 Husk å skrive et nyhetsinnlegg dersom endringene er omfattende!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-manual/462)
<!-- Reviewable:end -->


This pull request enhances the documentation for accessing external Google Cloud resources using Maskinporten-tokens and Skyporten. It introduces a new guide for the `ssb-gcp-identity-client` Python package, adds navigation to this documentation, and provides improved configuration and usage examples for Skyporten integration.

**New documentation and navigation:**

* Added a new documentation page, `ssb-gcp-identity-client.qmd`, detailing installation, usage, and examples for the `ssb-gcp-identity-client` Python package, including how to authenticate against external Google Cloud resources using Maskinporten-tokens via Skyporten.
* Updated the Quarto navigation (`_quarto.yml`) to include the new `ssb-gcp-identity-client.qmd` page under the statistikkere section.

**Skyporten configuration and usage improvements:**

* Added a detailed example configuration for Skyporten in the Maskinporten Guardian documentation, showing how to set up claim mappers for Skyporten audience.
* Improved code examples to illustrate how to request access tokens for external resources via Skyporten, including the use of the `accessTokenAudience` parameter for specifying the intended audience.
