### PR TITLE
Update versioning guidelines in navnestandard.qmd

### DIFF
--- a/dapla-manual/statistikkere/navnestandard.qmd
+++ b/dapla-manual/statistikkere/navnestandard.qmd
@@ -211,14 +211,21 @@ ssb-dapla-example-data-produkt-prod/
 
 ## Versjonering av datasett
 
-Versjonering er obligatorisk når man jobber med data på dapla. Hovedgrunnen til at vi versjonerer er for å dekke kravet om uforanderlighet og etterprøvbarehet: at data-konsumenter (menneske eller maskin) skal ha kontroll på endringer. Derfor skal et datasett som er brukt i statistikkproduksjon aldri slettes - det skal opprettes en ny versjon av datasettet. Les mer om prinsippet om uforanderlighet av data på [confluence-siden til IT-Arkitektur](https://statistics-norway.atlassian.net/wiki/spaces/Arkitektur/pages/2839707937/Prinsipp+1+Uforanderlighet+av+data).
+**Versjonering er obligatorisk** når man jobber med data på dapla. Hovedgrunnen til at vi versjonerer er for å dekke kravet om uforanderlighet og etterprøvbarehet: at data-konsumenter (menneske eller maskin) skal ha kontroll på endringer. Derfor skal et datasett som er brukt i statistikkproduksjon aldri slettes - det skal opprettes en ny versjon av datasettet. Les mer om prinsippet om uforanderlighet av data på [confluence-siden til IT-Arkitektur](https://statistics-norway.atlassian.net/wiki/spaces/Arkitektur/pages/2839707937/Prinsipp+1+Uforanderlighet+av+data).
 
 Kort fortalt innebærer versjonering av data at datasettene har versjonsnummer før filendelsen.
 For eksempel: *framskrevne-befolkningsendringer_p2019_p2050**\_v1**.parquet*
 
+::: {.callout-warning}
+## Mulighet til å lagre uversjonert fil
+Når man lagrer den obligatoriske versjonerte filen, har man mulighet til å samtidig lagre en uversjonert versjon. Feks. "filnavn_v1.parquet" + "filnavn.parquet". Dette forenkler konsumeringen av den uversjonerte filen. MEN, det kommer med noen mulige "feller":
+1. Hvordan sikrer man reproduserbarhet, når det ikke logges hos konsumenten hvilken versjon av filen som ble konsumert?
+2. Kan du garantere at du alltid skriver over den uversjonerte filen, eller er det en mulighet for at den kan bli "hengende bak" de versjonerte filene?
+:::
+
 ::: {.callout-note}
-## Unntak til versjonering: nyeste versjon og temporære data
-Nyeste versjon kan lagres uten versjonsnummer. Dette er for at man enkelt skal kunne lese inn siste versjon av et datasett (ved å utelate versjonssuffiks). I tilegg trenger man ikke versjonere temporære data. 
+## Unntak til versjonering: temporære data
+Man trenger ikke versjonere temporære data. 
 :::
 
 ### Når skal man lagre ny versjon?

--- a/dapla-manual/statistikkere/navnestandard.qmd
+++ b/dapla-manual/statistikkere/navnestandard.qmd
@@ -218,7 +218,7 @@ For eksempel: *framskrevne-befolkningsendringer_p2019_p2050**\_v1**.parquet*
 
 ::: {.callout-warning}
 ## Mulighet til å lagre uversjonert fil
-Når man lagrer den obligatoriske versjonerte filen, har man mulighet til å samtidig lagre en uversjonert versjon. Feks. "filnavn_v1.parquet" + "filnavn.parquet". Dette forenkler konsumeringen av den uversjonerte filen. MEN, det kommer med noen mulige "feller":
+Når man lagrer den obligatoriske versjonerte filen, har man mulighet til å samtidig lagre en uversjonert versjon. Feks. "filnavn_v1.parquet" + "filnavn.parquet". Dette gjør at konsumenten til en hver tid bruker "nyeste" versjon av fila, og kan derfor forenkle konsumeringen av den uversjonerte filen. Men, det er noen ting man bør være OBS på:
 1. Hvordan sikrer man reproduserbarhet, når det ikke logges hos konsumenten hvilken versjon av filen som ble konsumert?
 2. Kan du garantere at du alltid skriver over den uversjonerte filen, eller er det en mulighet for at den kan bli "hengende bak" de versjonerte filene?
 :::

--- a/dapla-manual/statistikkere/navnestandard.qmd
+++ b/dapla-manual/statistikkere/navnestandard.qmd
@@ -1,6 +1,6 @@
 ---
 title: Navnestandard
-date-modified: 09/07/2025
+date-modified: 02/12/2025
 lightbox: true
 ---
 

--- a/dapla-manual/statistikkere/navnestandard.qmd
+++ b/dapla-manual/statistikkere/navnestandard.qmd
@@ -221,6 +221,7 @@ For eksempel: *framskrevne-befolkningsendringer_p2019_p2050**\_v1**.parquet*
 Når man lagrer den obligatoriske versjonerte filen, har man mulighet til å samtidig lagre en uversjonert versjon. Feks. "filnavn_v1.parquet" + "filnavn.parquet". Dette gjør at konsumenten til en hver tid bruker "nyeste" versjon av fila, og kan derfor forenkle konsumeringen av den uversjonerte filen. Men, det er noen ting man bør være OBS på:
 1. Hvordan sikrer man reproduserbarhet, når det ikke logges hos konsumenten hvilken versjon av filen som ble konsumert?
 2. Kan du garantere at du alltid skriver over den uversjonerte filen, eller er det en mulighet for at den kan bli "hengende bak" de versjonerte filene?
+Det anbefales derfor kun å benytte filnavn med versjonsnummer (unngå uversjonerte filer)! Dette vil også forenkle dokumentasjon av datasett i DataDoc, tilgjengeliggjøring i datakatalogen, og er nødvendig for en ryddig deling av data.
 :::
 
 ::: {.callout-note}


### PR DESCRIPTION
Added a warning about the possibility of storing unversioned files alongside versioned ones, including potential pitfalls. Clarified the exceptions to versioning, specifying that only temporary data does not require versioning.

🤖 Automatisk beskjed 🤖

Har du husket å lese gjennom [retningslinjene for å bidra til manualen](https://manual.dapla.ssb.no/statistikkere/appendix/contribution.html)?
👉 Husk å skrive et nyhetsinnlegg dersom endringene er omfattende!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-manual/478)
<!-- Reviewable:end -->
