### PR TITLE
Vardef Forvaltning: Fix missing segment in link 

### DIFF
--- a/dapla-manual/statistikkere/vardef-forvaltning.qmd
+++ b/dapla-manual/statistikkere/vardef-forvaltning.qmd
@@ -46,7 +46,7 @@ code-links:
       target: "_blank"
     - text: sjekk_migrerte_variabeldefinisjoner.ipynb
       icon: file-code
-      href: https://github.com/statisticsnorway/dapla-toolbelt-metadata/blob/main/demo/sjekk_migrerte_variabeldefinisjoner.ipynb
+      href: https://github.com/statisticsnorway/dapla-toolbelt-metadata/blob/main/demo/variable_definitions/sjekk_migrerte_variabeldefinisjoner.ipynb
       target: "_blank"
     - text: slett_utkast_variabeldefinisjon.ipynb
       icon: file-code


### PR DESCRIPTION
Link to Notebook `sjekk_migrerte_variabeldefinisjoner` was missing  `variable_definitions` in path

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-manual/506)
<!-- Reviewable:end -->
