### PR TITLE
Update deling-av-data.qmd

### DIFF
--- a/dapla-manual/statistikkere/deling-av-data.qmd
+++ b/dapla-manual/statistikkere/deling-av-data.qmd
@@ -131,7 +131,7 @@ Over ser vi at teamet **dapla-example** har tre delt-bøtter:
 3. ssb-dapla-example-data-delt-ameld-pii-prod
  
 
-De to første bøttene har de gitt lese- og skrivetilgang til **developers** i **play-obr-b**. Den tredje bøtten er en delomat der **data-admins** i **dapla-felles** har lesetilgang (uten at det delende teamet har det).
+De to første bøttene har de gitt lese- og skrivetilgang til **developers** i **play-obr-b**. Den tredje bøtten er en delomat der **developers** i **dapla-felles** har lesetilgang (uten at det delende teamet har det).
 
 Når man har gjort endringer i `iam.yaml` så gjør man følgende:
 


### PR DESCRIPTION
Skrivefeil. Vises til dapla-felles-developers i eksempelet over, men her er det plutselig data-admins i dapla-felles.

🤖 Automatisk beskjed 🤖

Har du husket å lese gjennom [retningslinjene for å bidra til manualen](https://manual.dapla.ssb.no/statistikkere/appendix/contribution.html)?
👉 Husk å skrive et nyhetsinnlegg dersom endringene er omfattende!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-manual/532)
<!-- Reviewable:end -->
