### PR TITLE
Add warning about trying 'ssb-project build' with github creation when token lacks workflow permission

### DIFF
--- a/dapla-manual/statistikkere/ssb-project.qmd
+++ b/dapla-manual/statistikkere/ssb-project.qmd
@@ -106,6 +106,12 @@ Hvis du stod i hjemmemappen din på når du skrev inn kommandoen over i terminal
 
 Over så opprettet vi et **ssb-project** uten å opprette et GitHub-repo. Hvis du ønsker å opprette et GitHub-repo også må du endre kommandoen over til:
 
+::: {.callout-warning appearance="simple"}
+For at dette skal fungere **må** din personal access token (PAT) ha workflow tilgangen! [Se steg 7 her.](./github-oppsett.html#personal-access-token-pat)
+
+Hvis din token mangler denne tilgangen vil repoet på GitHub være tomt når ssb-project build er ferdig.
+:::
+
 ```{.bash filename="terminal"}
 ssb-project create stat-testprod --github --github-token='blablabla'
 ```


### PR DESCRIPTION
A common issue when people are trying to make new repos is that they are lacking the workflow permission on their token.

The result of trying without that permission is the repo being created empty. To fix this, the simplest way for the user is to have the repo deleted and try again. Expecting people to be able to connect their local repo to the remote is asking too much.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-manual/533)
<!-- Reviewable:end -->
