### PR TITLE
Oppdatert navnestandard

### DIFF
--- a/dapla-manual/references.bib
+++ b/dapla-manual/references.bib
@@ -16,8 +16,8 @@
   year = {2021},
   issue_date = {16 November 2021},
   publisher = {Statistisk sentralbyrå},
-  url = {https://ssbno.sharepoint.com/sites/Internedokumenter/Delte%20dokumenter/Forms/AllItems.aspx?id=%2Fsites%2FInternedokumenter%2FDelte%20dokumenter%2FInterne%20dokumenter%202021%2F2021%2D17%20Datatilstander%20i%20SSB%20%2Epdf&parent=%2Fsites%2FInternedokumenter%2FDelte%20dokumenter%2FInterne%20dokumenter%202021},
-  numpages = {13}
+  url = {https://www.ssb.no/teknologi-og-innovasjon/metoder-og-dokumentasjon/datatilstander-ssb-3.utgave/_/attachment/inline/411ebf27-1ce3-42d3-a52e-47fd8d0af188:706ed5ec7279bbea5801a2a27bdc9e8a015280dd/NOT2026-04.pdf},
+  numpages = {15}
 }
 
 @unpublished{tilgangsstyring,

--- a/dapla-manual/references.bib
+++ b/dapla-manual/references.bib
@@ -3,10 +3,10 @@
 @unpublished{datatilstander2,
   author = {Standardutvalget},
   title = {Datatilstander i  SSB},
-  year = {2023},
-  issue_date = {6 October 2023},
+  year = {2026},
+  issue_date = {21 January 2026},
   publisher = {Statistisk sentralbyrå},
-  url = {https://ssbno.sharepoint.com/sites/Internedokumenter/Delte%20dokumenter/Forms/AllItems.aspx?id=%2Fsites%2FInternedokumenter%2FDelte%20dokumenter%2FInterne%20dokumenter%202023%2F2023%2D14%20Datatilstander%20i%20SSB%2Epdf&parent=%2Fsites%2FInternedokumenter%2FDelte%20dokumenter%2FInterne%20dokumenter%202023},
+  url = {https://www.ssb.no/teknologi-og-innovasjon/metoder-og-dokumentasjon/datatilstander-ssb-3.utgave/_/attachment/inline/411ebf27-1ce3-42d3-a52e-47fd8d0af188:706ed5ec7279bbea5801a2a27bdc9e8a015280dd/NOT2026-04.pdf},
   numpages = {15}
 }
 
@@ -16,8 +16,8 @@
   year = {2021},
   issue_date = {16 November 2021},
   publisher = {Statistisk sentralbyrå},
-  url = {https://www.ssb.no/teknologi-og-innovasjon/metoder-og-dokumentasjon/datatilstander-ssb-3.utgave/_/attachment/inline/411ebf27-1ce3-42d3-a52e-47fd8d0af188:706ed5ec7279bbea5801a2a27bdc9e8a015280dd/NOT2026-04.pdf},
-  numpages = {15}
+  url = {https://ssbno.sharepoint.com/sites/Internedokumenter/Delte%20dokumenter/Forms/AllItems.aspx?id=%2Fsites%2FInternedokumenter%2FDelte%20dokumenter%2FInterne%20dokumenter%202021%2F2021%2D17%20Datatilstander%20i%20SSB%20%2Epdf&parent=%2Fsites%2FInternedokumenter%2FDelte%20dokumenter%2FInterne%20dokumenter%202021},
+  numpages = {13}
 }
 
 @unpublished{tilgangsstyring,

--- a/dapla-manual/statistikkere/datatilstander.qmd
+++ b/dapla-manual/statistikkere/datatilstander.qmd
@@ -4,7 +4,7 @@ date-modified: 01/01/2025
 lightbox: true
 ---
 
-En datatilstand er et resultat av at et datasett har gått gjennom gitte operasjoner og prosesser [@datatilstander2 pp. 5]. Denne siden er ment som en kort innføring i de forskjellige datatilstandene. Siden er basert på det interne dokumentet [Datatilstander SSB - 2. utgave](https://ssbno.sharepoint.com/sites/Internedokumenter/Delte%20dokumenter/Forms/AllItems.aspx?id=%2Fsites%2FInternedokumenter%2FDelte%20dokumenter%2FInterne%20dokumenter%202023%2F2023%2D14%20Datatilstander%20i%20SSB%2Epdf&parent=%2Fsites%2FInternedokumenter%2FDelte%20dokumenter%2FInterne%20dokumenter%202023). Definisjonene er direkte utdrag fra dette dokumentet. Se interndokumentet for en mer grundig gjennomgang av datatilstander i SSB.
+En datatilstand er et resultat av at et datasett har gått gjennom gitte operasjoner og prosesser [@datatilstander2 pp. 5]. Denne siden er ment som en kort innføring i de forskjellige datatilstandene. Siden er basert på det interne dokumentet [Datatilstander SSB - 3. utgave](https://www.ssb.no/teknologi-og-innovasjon/metoder-og-dokumentasjon/datatilstander-ssb-3.utgave/_/attachment/inline/411ebf27-1ce3-42d3-a52e-47fd8d0af188:706ed5ec7279bbea5801a2a27bdc9e8a015280dd/NOT2026-04.pdf). Definisjonene er direkte utdrag fra dette dokumentet. Se interndokumentet for en mer grundig gjennomgang av datatilstander i SSB.
 
 I SSB skiller vi mellom fem datatilstander:
 
@@ -14,7 +14,7 @@ I SSB skiller vi mellom fem datatilstander:
 4. Statistikk
 5. Utdata
 
-Alle datatilstander er obligatoriske bortsett fra **inndata**. @fig-datatilstander viser hvordan de forskjellige datatilstandene henger sammen.
+Alle datatilstander er obligatoriske bortsett fra **inndata** og **statistikkdata**. Statistikkdata er ikke obligatorisk dersom den ikke skiller seg fra utdata. @fig-datatilstander viser hvordan de forskjellige datatilstandene henger sammen.
 
 ![En grafisk fremstilling av forskjellene mellom datatilstandene i SSB [@datatilstander2].](../images/datatilstander.png){fig-alt="Figur som viser ulikhetene mellom datatilstandene som er definert i SSB." width="100%" #fig-datatilstander}
 
@@ -41,6 +41,8 @@ Statistikk er "Tallfestede opplysninger om en gruppe eller et fenomen, og som ko
 Statistikk er ofte aggregerte data eller estimerte størrelser. Vi skiller mellom ujustert statistikk og justert statistikk. Indekser og sesongjusterte tall er eksempler på justert statistikk [@datatilstander2 pp. 10].
 
 Statistikk kan være inndata til andre statistikker, og kan dermed inneholde konfidensielle og detaljerte data som ikke publiseres.
+
+Dersom statistikkdata er ikke obligatorisk dersom det ikke skiller seg fra utdata. 
 
 ## Utdata
 Utdata er **statistikk der kravene til konfidensialtet er ivaretatt**. Dette er datatilstanden som publiseres. Eksempler inkluderer: *statistikkbanktabeller*, *tabelloppdrag* og *internasjonal rapportering* [@datatilstander2 pp. 11]. Utdata lagres i bøtten `ssb-<teamnavn>-data-produkt-produkt`.

--- a/dapla-manual/statistikkere/navnestandard.qmd
+++ b/dapla-manual/statistikkere/navnestandard.qmd
@@ -142,6 +142,36 @@ Under finner du et utvalg eksempler på gyldige filnavn for ulike tidsspenn.
 | Kvartalene 1, 2, 3 og 4 i 2018 | *varehandel_p2018-Q1_p2018-Q4_v1.parquet* |
 | Dato 31.12.2024 og tid 23:59:30.000 | *skjema_p2024-12-31T23-59-30.000_v1.parquet* |
 
+## Variabelnavn: VarDef og DataDoc
+
+I tillegg til filnavn finnes det [retningslinjer for variabelnavn/kortnavn (WebSak+)](https://ssb.acossky.no/saksbehandling/sak/1100012326/jp/1100050167). Retningslinjene er todelt: **del A** inneholder *krav* for kortnavn, **del B** er anbefalinger.
+
+#### A) Krav
+
+Kortnavnet skal kun inneholde **a-z** (bare små bokstaver), **0-9** og **_** (understrek). Minimumslengden på kortnavnet er 2 tegn, og kortnavnet skal starte med en bokstav.
+
+Dersom det brukes generiske navn, som «kilde», «total» eller «kode», skal kortnavnet
+spesifiseres vha. suffiks, f.eks. kilde_innt.
+
+#### B) Anbefalinger
+
+Informasjon kan presiseres ved bruk av prefiks og suffiks. Dette er spesielt nyttig med tanke på
+de unike kortnavnene i Vardef. Flere variabler kan ha samme navn, men ulik definisjon. En kan
+da bruke prefiks for å skille dem, f.eks. ved bruk av enhetstype som i pers_innt og hush_innt.
+Dersom variabler både har samme enhetstype og navn, kan en også f.eks. legge til statistikkens
+kortnavn for å skille dem fra hverandre som i selvangivelse_pers_innt.
+
+Dersom en ønsker å detaljere informasjon om en variabel, foreslås bruk av suffiks, f.eks
+pers_id_mor. Suffiks foreslår også brukt for aggregerte variabler, f.eks.pers_innt_gjsnitt.
+Det anbefales at “æ”, “ø” og “å” erstattes med hhv. “ae”, “oe” og “aa” (eksempel: “naering”,
+“loenn” og “aar”). Det kan imidlertid velges andre erstatninger f.eks. der disse har vært brukt
+lenge, f.eks. «lonn» (lønn).
+
+Bruk kortnavn som har en viss semantisk likhet med variabelens fulle navn, f.eks.
+bra (bruksareal) og intfou (interne FoU-kostnader).
+
+Det foreslås ikke noen grense for hvor langt et kortnavn kan være. Her må en balansere behovet
+for et beskrivende navn mot hva som er hensiktsmessig lengde m.h.t. programmering.
 
 ## Partisjonerte data
 
@@ -329,4 +359,4 @@ bruke *versjonsnummer 0* i filnavnet.
 
 Dette versjonsnummeret skal kun brukes
 midlertidig fram til datasettet oppnår stabil tilstand. Ved stabil tilstand
-byttes versjonsnummer for datasettet til 1 eller høyere.
+byttes versjonsnummer for datasettet til 1 eller høyere. 


### PR DESCRIPTION
Ny utgave av datatilstandsdokumentet: https://www.ssb.no/teknologi-og-innovasjon/metoder-og-dokumentasjon/datatilstander-ssb-3.utgave/_/attachment/inline/411ebf27-1ce3-42d3-a52e-47fd8d0af188:706ed5ec7279bbea5801a2a27bdc9e8a015280dd/NOT2026-04.pdf

statistikkdata ikke lenger obligatorisk (dersom den er lik utdata)

oppdatere lenke

oppdatere navnestandard (ny standard for variabelnavn)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-manual/543)
<!-- Reviewable:end -->
