### PR TITLE
Remove concurrency from delete preview action

### DIFF
--- a/.github/workflows/delete-pr-preview.yml
+++ b/.github/workflows/delete-pr-preview.yml
@@ -8,10 +8,6 @@ permissions:
   contents: write
   pull-requests: read
 
-concurrency:
-  group: gh-pages-updates
-  cancel-in-progress: false
-
 jobs:
   cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Concurrency groups was previously added to prevent race conditions between workflows operating on the gh-pages branch. However, GitHub's concurrency behavior only allows one running job and one pending job per group. 

This causes unexpected behavior when the `render-preview` isn't finished before a PR is merged. The `render-and-publish` and `delete-pr-preview` jobs compete for the pending slot, leading to jobs being cancelled and updates not being published.

Removing the concurrency group from delete-pr-preview will hopefully prevent the workflow cancellation issues.

(in regards to the original race conditions issues, the publish job in `render-and-publish` will [automatically attempt to rebase](https://github.com/JamesIves/github-pages-deploy-action/blob/3d4d9b15f58f36c5083a7af35b40e8b2c7078144/src/git.ts#L274) if `delete-pr-preview` has made any changes to the gh-pages branch before the job is finished)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-manual/551)
<!-- Reviewable:end -->
