### PR TITLE
Fix link to pyproject.toml in Kildomaten documentation

### DIFF
--- a/dapla-manual/statistikkere/kildomaten.qmd
+++ b/dapla-manual/statistikkere/kildomaten.qmd
@@ -579,7 +579,7 @@ print(metadata_generation == blob.generation)
 ### Pakker og oppdateringer
 
 Det finnes et fast sett med pakker som er tilgjengelig i Kildomaten. Disse pakkene kan sees
-under `[tool.poetry.dependencies]`-blokken [her](https://github.com/statisticsnorway/dapla-automation-processor/blob/main/pyproject.toml).
+under `[tool.poetry.dependencies]`-blokken [her](https://github.com/statisticsnorway/dapla-automation-processor/blob/main/source_data/pyproject.toml).
 
 Dette repoet oppfører seg som et vanlig Poetry-prosjekt, og blir brukt som grunnlaget for alle Kildomaten-jobber.
 


### PR DESCRIPTION
The link for the `pyproject.toml`-file showing the dependencies of kildomat appeared broken. I think this should be the correct link.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-manual/564)
<!-- Reviewable:end -->
