### PR TITLE
GHA: update render and publish workflow

### DIFF
--- a/.github/workflows/render-and-publish.yml
+++ b/.github/workflows/render-and-publish.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tinytex: true
       - name: Render Quarto


### PR DESCRIPTION
add the github token to the quarto install step
to avoid being rate-limited by the github API
when querying github for the latest tinytex release

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/statisticsnorway/dapla-manual/595)
<!-- Reviewable:end -->
